### PR TITLE
CLI: enables image drop-in from file explorer

### DIFF
--- a/cli_chat.py
+++ b/cli_chat.py
@@ -116,6 +116,7 @@ def chat(args, tokenizer, vl_chat_processor, vl_gpt, generation_config):
                 while cur_img_idx < num_images:
                     try:
                         image_file = input(f"({cur_img_idx + 1}/{num_images}) Input the image file path: ")
+                        image_file = image_file.strip() # trim whitespaces around path, enables drop-in from for example Dolphin
 
                     except KeyboardInterrupt:
                         print()


### PR DESCRIPTION
When dropping in an image from e.g. Dolphin, a whitespace is being appended, which breaks the img path parsing; this PR fixes that with a simple strip.